### PR TITLE
噗幣表情符號上限修正

### DIFF
--- a/extension/adapter.js
+++ b/extension/adapter.js
@@ -292,16 +292,16 @@ PlurkEmotiland.prototype.getDefaultSmiles = function(callback){
 
 PlurkEmotiland.prototype.isPremium = function(callback){
 	if(GLOBAL){
-		return callback && callback(GLOBAL.page_user.premium);
+		return callback && callback(GLOBAL.session_user.premium);
 	}
 	getLocal('GLOBAL', function(GLOBAL){
-		callback && callback(GLOBAL.page_user.premium);
+		callback && callback(GLOBAL.session_user.premium);
 	});	
 }
 
 PlurkEmotiland.prototype.getStorageLimit = function(callback){
 	this.isPremium(function(isPremium){
-		console.info('上限', isPremium ? 500 : 60)
-		callback && callback(isPremium ? 500 : 60);
+		console.info('上限', isPremium ? 800 : 60)
+		callback && callback(isPremium ? 800 : 60);
 	});
 }


### PR DESCRIPTION
噗幣使用者表情符號上限目前是800個，另外檢查是否擁有噗幣應該使用 session_user